### PR TITLE
Simplify dark mode

### DIFF
--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -59,21 +59,16 @@ class MyDocument extends Document {
                   document.body.className = newTheme;
                   window.__onThemeChange(newTheme);
                 }
-                var preferredTheme;
-                try {
-                  preferredTheme = localStorage.getItem('theme');
-                } catch (err) { }
                 window.__setPreferredTheme = function(newTheme) {
                   setTheme(newTheme);
                   try {
                     localStorage.setItem('theme', newTheme);
                   } catch (err) {}
                 }
-                var darkQuery = window.matchMedia('(prefers-color-scheme: dark)');
-                darkQuery.addListener(function(e) {
-                  window.__setPreferredTheme(e.matches ? 'dark' : 'light')
-                });
-                setTheme(preferredTheme || (darkQuery.matches ? 'dark' : 'light'));
+                try {
+                  const preferredTheme = localStorage.getItem('theme');
+                  setTheme(preferredTheme || 'dark');
+                } catch (err) { }
               })();
             `,
             }}


### PR DESCRIPTION
Closes #91

Dark / Light mode has been simplified, to only get the mode to display in the localStorage (default to dark). 
It doesn't check for the system preferences anymore.