### PR TITLE
Update Meilisearch version in ci

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
     container: cypress/browsers:node12.18.3-chrome87-ff82
     services:
       meilisearch:
-        image: getmeili/meilisearch:latest
+        image: getmeili/meilisearch:v0.24.0
         env:
           MEILI_MASTER_KEY: 'masterKey'
           MEILI_NO_ANALYTICS: 'true'


### PR DESCRIPTION
Using the `latest` version of meilisearch in the CI, while the demo movies instance in still in v0.24 may cause problem. 
This PR changes it by replacing `latest` by `v0.24.0`