### PR TITLE
Fix warnings on yarn dev

### DIFF
--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -1,8 +1,6 @@
 module.exports = {
   i18n: {
-    debug: process.env.NODE_ENV === 'development',
     defaultLocale: 'en',
     locales: ['en'],
-    fallbackLng: 'en',
   },
 }

--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,6 @@ const { i18n } = require('./next-i18next.config')
 module.exports = {
   reactStrictMode: true,
   poweredByHeader: false,
-  webpack5: true,
   webpack: config => {
     // Unset client-side javascript that only works server-side
     config.resolve.fallback = { fs: false, module: false }


### PR DESCRIPTION
Some options are now invalid after upgrading the `next` and `next-i18next` packages. I just removed them and checked that everything still works fine