### PR TITLE
Fix usage of deprecated `actions/upload-artifact`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,12 +52,12 @@ jobs:
           wait-on: "http://localhost:3000"
           command: yarn cy:run
           config-file: cypress.config.js
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: cypress-screenshots
           path: cypress/screenshots
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: cypress-videos


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #525 

## What does this PR do?
- This moves `actions/upload-artifact` in `.github/workflows/tests.yml` away from a deprecated version.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?