### PR TITLE
Fix security vulnerabilities in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "babel-loader": "^10.0.0",
     "babel-plugin-macros": "^3.1.0",
     "babel-plugin-styled-components": "^2.1.4",
-    "bun": "1.1.3",
+    "bun": "1.1.30",
     "eslint": "7.32.0",
     "eslint-config-next": "^14.1.0",
     "eslint-config-prettier": "^8.3.0",
@@ -59,6 +59,7 @@
     "typescript": "5.3.3"
   },
   "resolutions": {
-    "pbkdf2": "3.1.3"
+    "pbkdf2": "3.1.3",
+    "@babel/runtime": "7.27.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1186,14 +1186,7 @@
     pirates "^4.0.6"
     source-map-support "^0.5.16"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.5", "@babel/runtime@^7.17.2", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.3", "@babel/runtime@^7.18.9", "@babel/runtime@^7.5.0", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4":
-  version "7.26.7"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.7.tgz#f4e7fe527cd710f8dc0618610b61b4b060c3c341"
-  integrity sha512-AOPI3D+a8dXnja+iwsUqGRjr1BbZIe771sXdapOtYI531gSqpi92vXivKcq2asu/DFpdl1ceFAKZyRzK2PCVcQ==
-  dependencies:
-    regenerator-runtime "^0.14.0"
-
-"@babel/runtime@^7.27.6":
+"@babel/runtime@7.27.6", "@babel/runtime@^7.0.0", "@babel/runtime@^7.10.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.5", "@babel/runtime@^7.17.2", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.3", "@babel/runtime@^7.18.9", "@babel/runtime@^7.27.6", "@babel/runtime@^7.5.0", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4":
   version "7.27.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.27.6.tgz#ec4070a04d76bae8ddbb10770ba55714a417b7c6"
   integrity sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==
@@ -1761,45 +1754,45 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@oven/bun-darwin-aarch64@1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@oven/bun-darwin-aarch64/-/bun-darwin-aarch64-1.1.3.tgz#0c5a2b9c24981969c4f4d87d1dae51d16a3e4659"
-  integrity sha512-EgcHnvwC/A6WoF2F6gV1cc09i5CsYbPM6FX0xyEViUuyvC00z9SmhgqvocGFa1eFmKQODQBIZsovxEZxhLqfQw==
+"@oven/bun-darwin-aarch64@1.1.30":
+  version "1.1.30"
+  resolved "https://registry.yarnpkg.com/@oven/bun-darwin-aarch64/-/bun-darwin-aarch64-1.1.30.tgz#19e3b1a38bfa148fd02d3f73022b2f71e0aa3c39"
+  integrity sha512-D07QioP+QXlouvIqQIS+7r2zq4lTNd6he79rhKsRQRZGFf9i3NPu87zspUpCaFEu//DZ35DYTt+5anQpAzpoxA==
 
-"@oven/bun-darwin-x64-baseline@1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@oven/bun-darwin-x64-baseline/-/bun-darwin-x64-baseline-1.1.3.tgz#f4119935c6e5eb77441f45ed30e0d738b9c7c5fa"
-  integrity sha512-vaxqGRsIJ+lSmFBEACapgQS+mHBSS8XxCaQn7lbjUsr/LnFyNBzgSlDrU7cCVbxXMa7vVqDa/dRJ9rEpi0fqLA==
+"@oven/bun-darwin-x64-baseline@1.1.30":
+  version "1.1.30"
+  resolved "https://registry.yarnpkg.com/@oven/bun-darwin-x64-baseline/-/bun-darwin-x64-baseline-1.1.30.tgz#27f11147d758b58471ea1eca473d5ae21e27bac3"
+  integrity sha512-1kFUCxHx7WuEbLDmqm0m2UKBd3S4Ln6qKQ4gxU4umMLFkmvDJn6PszDruFInxGKFLoTAmbXNYNVWkkG/ekt/Lg==
 
-"@oven/bun-darwin-x64@1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@oven/bun-darwin-x64/-/bun-darwin-x64-1.1.3.tgz#b3ca38bce9fbf6b5d71778763c32c33fc31fc5fa"
-  integrity sha512-WNzpUzUampox5SKLx93JPcm8cRkjLyYKRqYhG7I21+psYtSicbcINoYjpW20NRdlk123u2rmb0a98dEPIj1Xaw==
+"@oven/bun-darwin-x64@1.1.30":
+  version "1.1.30"
+  resolved "https://registry.yarnpkg.com/@oven/bun-darwin-x64/-/bun-darwin-x64-1.1.30.tgz#ae96fb8eb0bcad68ad8631c6eecebdd8b04f94c1"
+  integrity sha512-xZ4gTehS6QwN6bsJfDycCNneKoUMaFUQhQg24bJzXS4JPDxeKg1W7PS5AE+U9apz5Dx6//+D4RwVpAPG2LXt0w==
 
-"@oven/bun-linux-aarch64@1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@oven/bun-linux-aarch64/-/bun-linux-aarch64-1.1.3.tgz#c015a9c2b86b86dd755c9b2454e0e1f8c1954ab8"
-  integrity sha512-s6rsbpsHzu19wl25WyAbi9yQRCOtigQN3IfbuiL+c71zctI5MGWdMz1yhBcjkFW64t656kGsvhHieS8n3rLjSw==
+"@oven/bun-linux-aarch64@1.1.30":
+  version "1.1.30"
+  resolved "https://registry.yarnpkg.com/@oven/bun-linux-aarch64/-/bun-linux-aarch64-1.1.30.tgz#7f7385b5259aa3986c996bc1f54322446bec0fd1"
+  integrity sha512-SfHHLlph6fptDXyyChcUkeDbEZr2ww1p2BucV6OrvzwTOPi8pVmXA4360YT8ggR/3AHPp4GO36VaD+FU2Ocbxw==
 
-"@oven/bun-linux-x64-baseline@1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@oven/bun-linux-x64-baseline/-/bun-linux-x64-baseline-1.1.3.tgz#5c1425a495db96f026fb7b3d3a7be9c571d4864d"
-  integrity sha512-mxw4Lo4c6epzkM/WTYbd8K2EeNoaMxzyYIB69mw26fSZmI/Sr4hmn14/SDZF6qwvnurignlqdYwWRasmhnC2hw==
+"@oven/bun-linux-x64-baseline@1.1.30":
+  version "1.1.30"
+  resolved "https://registry.yarnpkg.com/@oven/bun-linux-x64-baseline/-/bun-linux-x64-baseline-1.1.30.tgz#c6e9239fc17f730ef69671d7b9118861e8462cf8"
+  integrity sha512-/b/VuNOaAYmsVk9MvfwKcCYARJPUg78hebxNyD5DSajAf3dqtUSnf7QYcq/3mxWH++N+gM7uRTrGksGS63+ZUw==
 
-"@oven/bun-linux-x64@1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@oven/bun-linux-x64/-/bun-linux-x64-1.1.3.tgz#813c412d005b77b526fe4962a6efd6a58400652d"
-  integrity sha512-hCAuEKLSjd0XxhgU/K+aZIvmDVnkHK1mSbD7pGWvTN+z2g6Ac64tQSBin+TyhiS4DzOxr2nNelMllFjFMwOd+Q==
+"@oven/bun-linux-x64@1.1.30":
+  version "1.1.30"
+  resolved "https://registry.yarnpkg.com/@oven/bun-linux-x64/-/bun-linux-x64-1.1.30.tgz#de83bdeee1daa43d1eb49bd236ccd77bf26babb0"
+  integrity sha512-1mC39jQSaECytEKAZdCZmv3ZreMsp7aoxnBwmJtVd2Z7urnw17PKi4dKkZd/R+AubsNYtXtW4jeM8SEa5sUJRw==
 
-"@oven/bun-windows-x64-baseline@1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@oven/bun-windows-x64-baseline/-/bun-windows-x64-baseline-1.1.3.tgz#e394399c88c52ec261a3de93c6ab02e2f92251ab"
-  integrity sha512-LgGYYWA6f5FKp3QeT8PCQ6JpQkz2kLu21i6um4BYyh1U7hZb75LoLzetfhdOJa00hy9Zrt+8Z8QnQ7ffmGevyQ==
+"@oven/bun-windows-x64-baseline@1.1.30":
+  version "1.1.30"
+  resolved "https://registry.yarnpkg.com/@oven/bun-windows-x64-baseline/-/bun-windows-x64-baseline-1.1.30.tgz#311fed812c2b976bc309e5f4c6e14d8305fc3c1e"
+  integrity sha512-ERQ4/ogzbFvHjpyHcnruc8bnryvDvUoiWi6vczfQ4M/idJc+Kg5VSEJiF5k7946rIZGamG6QWgRxtpIglD4/Zw==
 
-"@oven/bun-windows-x64@1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@oven/bun-windows-x64/-/bun-windows-x64-1.1.3.tgz#ce4711b74921f8cd7723abdf5a98f8abaf3209ba"
-  integrity sha512-IBV+DCOAyaQGhtqQ0gliBprMRBoRGwDBSOQJrQ6Df/0t0R7eyJzl8SyR2C89jZ/vK4VsNMgEv5Mxa6zP7SSQOw==
+"@oven/bun-windows-x64@1.1.30":
+  version "1.1.30"
+  resolved "https://registry.yarnpkg.com/@oven/bun-windows-x64/-/bun-windows-x64-1.1.30.tgz#f12fb52f9c9568f70b4020473ad6510db0944cbb"
+  integrity sha512-mdRjNtD9NIA8CiH6N1zrIVE6oAtDko/c29H1s00UA+5O/WhXhg95G8IyInD8hN3vAEz8H2lGBgLG2EGfSFxnGg==
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
@@ -4216,19 +4209,19 @@ builtin-status-codes@^3.0.0:
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==
 
-bun@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/bun/-/bun-1.1.3.tgz#f7c259f7cdb302732ac508845318930c64b16d69"
-  integrity sha512-1jPSmSJcRlBmgBUFbaaw6DKy7HvyotWRNjafZKkhvVHoDhEXK1YRkHo99IG/0vvwj8BmkMnFpQu9R0T7JArllw==
+bun@1.1.30:
+  version "1.1.30"
+  resolved "https://registry.yarnpkg.com/bun/-/bun-1.1.30.tgz#c63152605870707d703c3fc0e49877d08e1eda27"
+  integrity sha512-ysRL1pq10Xba0jqVLPrKU3YIv0ohfp3cTajCPtpjCyppbn3lfiAVNpGoHfyaxS17OlPmWmR67UZRPw/EueQuug==
   optionalDependencies:
-    "@oven/bun-darwin-aarch64" "1.1.3"
-    "@oven/bun-darwin-x64" "1.1.3"
-    "@oven/bun-darwin-x64-baseline" "1.1.3"
-    "@oven/bun-linux-aarch64" "1.1.3"
-    "@oven/bun-linux-x64" "1.1.3"
-    "@oven/bun-linux-x64-baseline" "1.1.3"
-    "@oven/bun-windows-x64" "1.1.3"
-    "@oven/bun-windows-x64-baseline" "1.1.3"
+    "@oven/bun-darwin-aarch64" "1.1.30"
+    "@oven/bun-darwin-x64" "1.1.30"
+    "@oven/bun-darwin-x64-baseline" "1.1.30"
+    "@oven/bun-linux-aarch64" "1.1.30"
+    "@oven/bun-linux-x64" "1.1.30"
+    "@oven/bun-linux-x64-baseline" "1.1.30"
+    "@oven/bun-windows-x64" "1.1.30"
+    "@oven/bun-windows-x64-baseline" "1.1.30"
 
 busboy@1.6.0:
   version "1.6.0"
@@ -9914,11 +9907,6 @@ regenerator-runtime@^0.13.7:
   version "0.13.11"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
-
-regenerator-runtime@^0.14.0:
-  version "0.14.1"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
-  integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
 
 regenerator-transform@^0.15.2:
   version "0.15.2"


### PR DESCRIPTION
## Summary
- Fixed 2 open security vulnerabilities identified by Dependabot
- Updated bun from 1.1.3 to 1.1.30 to fix prototype pollution vulnerability (Alert #59)
- Added @babel/runtime resolution to 7.27.6 to fix RegExp complexity vulnerability (Alert #70)

## Security Details
### bun (Alert #59) - Medium severity
- **Issue**: Application-level Prototype Pollution vulnerability
- **Fix**: Updated from 1.1.3 to 1.1.30

### @babel/runtime (Alert #70) - Medium severity
- **Issue**: Inefficient RegExp complexity in generated code when transpiling named capturing groups
- **Fix**: Added resolution to force version 7.27.6 (newer than required 7.26.10)

## Test plan
- [x] Build passes successfully (`yarn build`)
- [x] Linter passes (`yarn lint`)
- [x] Verified correct versions installed

🤖 Generated with [Claude Code](https://claude.ai/code)